### PR TITLE
DM-50508: Fix rounding errors in positions and allow symmetry as a constraint

### DIFF
--- a/doc/changes/DM-47738.feature.rst
+++ b/doc/changes/DM-47738.feature.rst
@@ -1,0 +1,3 @@
+* Added ``Image.trimmed`` method to remove data below a threshold from an Image.
+* Added ``Image.at`` method to extract a single pixel from an Image.
+* Added slicing for ``Observation`` to slice along spectral or spatial dimension

--- a/doc/lsst.scarlet.lite/getting_started.rst
+++ b/doc/lsst.scarlet.lite/getting_started.rst
@@ -11,6 +11,7 @@ First we import the necessary modules needed to process the data:
 >>> import os
 >>> import numpy as np
 >>> import lsst.scarlet.lite as scl
+>>> import lsst.scarlet.lite.display
 >>> import matplotlib
 >>> import matplotlib.pyplot as plt
 >>> # Use a good colormap and don't interpolate the pixels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
    "numpy>=1.18",
    "scipy",
    "pydantic",
+   "Deprecated",
 ]
 dynamic = ["version"]
 
@@ -42,7 +43,7 @@ test = [
     "pytest >= 3.2",
 ]
 yaml = ["pyyaml >= 5.1"]
-plotting = ["matplotlib", "astropy < 7.0"]
+plotting = ["matplotlib", "astropy < 7"]
 
 [tool.setuptools.packages.find]
 where = ["python"]

--- a/python/lsst/scarlet/lite/blend.py
+++ b/python/lsst/scarlet/lite/blend.py
@@ -277,7 +277,7 @@ class Blend:
         for source in self.sources:
             source.parameterize(parameterization)
 
-    def conserve_flux(self, mask_footprint: bool = True) -> None:
+    def conserve_flux(self, mask_footprint: bool = True, weight_image: Image | None = None) -> None:
         """Use the source models as templates to re-distribute flux
         from the data
 
@@ -295,6 +295,9 @@ class Blend:
             The blend that is being fit
         mask_footprint:
             Whether or not to apply a mask for pixels with zero weight.
+        weight_image:
+            The weight image to use for the redistribution.
+            If `None` then the observation image is used.
         """
         observation = self.observation
         py = observation.psfs.shape[-2] // 2
@@ -303,10 +306,16 @@ class Blend:
         images = observation.images.copy()
         if mask_footprint:
             images.data[observation.weights.data == 0] = 0
-        model = self.get_model()
-        # Always convolve in real space to avoid FFT artifacts
-        model = observation.convolve(model, mode="real")
-        model.data[model.data < 0] = 0
+
+        if weight_image is None:
+            weight_image = self.get_model()
+            # Always convolve in real space to avoid FFT artifacts
+            weight_image = observation.convolve(weight_image, mode="real")
+
+            # Due to ringing in the PSF, the convolved model can have
+            # negative values. We take the absolute value to avoid
+            # negative fluxes in the flux weighted images.
+            weight_image.data[:] = np.abs(weight_image.data)
 
         for src in self.sources:
             if src.is_null:
@@ -319,9 +328,9 @@ class Blend:
             overlap = observation.bbox & src_box
             src_model = src_model.project(bbox=overlap)
             src_model = observation.convolve(src_model, mode="real")
-            src_model.data[src_model.data < 0] = 0
+            src_model.data[:] = np.abs(src_model.data)
             numerator = src_model.data
-            denominator = model[overlap].data
+            denominator = weight_image[overlap].data
             cuts = denominator != 0
             ratio = np.zeros(numerator.shape, dtype=numerator.dtype)
             ratio[cuts] = numerator[cuts] / denominator[cuts]

--- a/python/lsst/scarlet/lite/component.py
+++ b/python/lsst/scarlet/lite/component.py
@@ -254,13 +254,13 @@ class FactorizedComponent(Component):
                 self.peak[1] - self.bbox.origin[-1],
             )
 
-        # symmetry
-        if self.is_symmetric:
-            morph = prox_uncentered_symmetry(morph, peak, fill=0.0)
-
         # monotonicity
         if self.monotonicity is not None:
             morph = self.monotonicity(morph, cast(tuple[int, int], self.component_center))
+
+        # symmetry
+        if self.is_symmetric:
+            morph = prox_uncentered_symmetry(morph, peak, fill=0.0)
 
         if self.bg_thresh is not None and self.bg_rms is not None:
             bg_thresh = self.bg_rms * self.bg_thresh

--- a/python/lsst/scarlet/lite/component.py
+++ b/python/lsst/scarlet/lite/component.py
@@ -34,7 +34,7 @@ import numpy as np
 
 from .bbox import Box
 from .image import Image
-from .operators import Monotonicity, prox_uncentered_symmetry, prox_connected
+from .operators import Monotonicity, prox_connected, prox_uncentered_symmetry
 from .parameters import AdaproxParameter, FistaParameter, Parameter, parameter, relative_step
 
 

--- a/python/lsst/scarlet/lite/component.py
+++ b/python/lsst/scarlet/lite/component.py
@@ -294,7 +294,7 @@ class FactorizedComponent(Component):
             new_box = Box((1, 1), center).grow(self.padding) & model_box
         else:
             new_box = (
-                Box.from_data(significant, threshold=0).grow(self.padding) + self.bbox.origin
+                Box.from_data(significant, threshold=0).grow(self.padding) + self.bbox.origin  # type: ignore
             ) & model_box
         if new_box == self.bbox:
             return False

--- a/python/lsst/scarlet/lite/detect.py
+++ b/python/lsst/scarlet/lite/detect.py
@@ -63,6 +63,33 @@ def bounds_to_bbox(bounds: tuple[int, int, int, int]) -> Box:
     )
 
 
+def bbox_to_bounds(bbox: Box) -> tuple[int, int, int, int]:
+    """Convert a Box into the bounds of a Footprint
+
+    Notes
+    -----
+    Unlike slices, the bounds are _inclusive_ of the end points.
+
+    Parameters
+    ----------
+    bbox:
+        The `Box` to convert into bounds.
+
+    Returns
+    -------
+    result:
+        The bounds of the `Footprint` as a `tuple` of
+        ``(bottom, top, left, right)``.
+    """
+    bounds = (
+        bbox.origin[0],
+        bbox.origin[0] + bbox.shape[0] - 1,
+        bbox.origin[1],
+        bbox.origin[1] + bbox.shape[1] - 1,
+    )
+    return bounds
+
+
 @continue_class
 class Footprint:  # type: ignore # noqa
     @property
@@ -222,7 +249,7 @@ def get_detect_wavelets(images: np.ndarray, variance: np.ndarray, scales: int = 
 def detect_footprints(
     images: np.ndarray,
     variance: np.ndarray,
-    scales: int = 2,
+    scales: int = 1,
     generation: int = 2,
     origin: tuple[int, int] | None = None,
     min_separation: float = 4,

--- a/python/lsst/scarlet/lite/detect.py
+++ b/python/lsst/scarlet/lite/detect.py
@@ -66,10 +66,6 @@ def bounds_to_bbox(bounds: tuple[int, int, int, int]) -> Box:
 def bbox_to_bounds(bbox: Box) -> tuple[int, int, int, int]:
     """Convert a Box into the bounds of a Footprint
 
-    Notes
-    -----
-    Unlike slices, the bounds are _inclusive_ of the end points.
-
     Parameters
     ----------
     bbox:
@@ -80,6 +76,10 @@ def bbox_to_bounds(bbox: Box) -> tuple[int, int, int, int]:
     result:
         The bounds of the `Footprint` as a `tuple` of
         ``(bottom, top, left, right)``.
+
+    Notes
+    -----
+    Unlike slices, the bounds are _inclusive_ of the end points.
     """
     bounds = (
         bbox.origin[0],

--- a/python/lsst/scarlet/lite/detect_pybind11.cc
+++ b/python/lsst/scarlet/lite/detect_pybind11.cc
@@ -256,6 +256,10 @@ public:
         return _bounds;
     }
 
+    void addPeak(Peak peak){
+        peaks.push_back(peak);
+    }
+
 private:
     MatrixB _data;
     Bounds _bounds;
@@ -376,11 +380,11 @@ PYBIND11_MODULE(detect_pybind11, mod) {
           "Get a list of peaks in a footprint created by get_connected_pixels");
 
   mod.def("get_footprints", &get_footprints<MatrixF, float>,
-          "Create a list of all of the footprints in an image, with their peaks"
+          "Create a list of all of the footprints in an image, with their peaks",
           "image"_a, "min_separation"_a, "min_area"_a, "peak_thresh"_a, "footprint_thresh"_a,
           "find_peaks"_a=true, "y0"_a=0, "x0"_a=0);
   mod.def("get_footprints", &get_footprints<MatrixD, double>,
-          "Create a list of all of the footprints in an image, with their peaks"
+          "Create a list of all of the footprints in an image, with their peaks",
           "image"_a, "min_separation"_a, "min_area"_a, "peak_thresh"_a, "footprint_thresh"_a,
           "find_peaks"_a=true, "y0"_a=0, "x0"_a=0);
 
@@ -389,7 +393,8 @@ PYBIND11_MODULE(detect_pybind11, mod) {
              "footprint"_a, "peaks"_a, "bounds"_a)
         .def_property_readonly("data", &Footprint::getFootprint)
         .def_readwrite("peaks", &Footprint::peaks)
-        .def_property_readonly("bounds", &Footprint::getBounds);
+        .def_property_readonly("bounds", &Footprint::getBounds)
+        .def("add_peak", &Footprint::addPeak);
 
   py::class_<Peak>(mod, "Peak")
         .def(py::init<int, int, double>(),

--- a/python/lsst/scarlet/lite/image.py
+++ b/python/lsst/scarlet/lite/image.py
@@ -734,6 +734,50 @@ class Image:
             yx0 = self.yx0
         return Image(data, bands, yx0)
 
+    def trimmed(self, threshold: float = 0) -> Image:
+        """Return a copy of the image trimmed to a threshold.
+
+        Parameters
+        ----------
+        threshold:
+            The threshold to use for trimming the image.
+
+        Returns
+        -------
+        image:
+            A copy of the image trimmed to the threshold.
+        """
+        data = self.data.copy()
+        bbox = Box.from_data(data, threshold=threshold)
+        data = data[bbox.slices]
+        y0, x0 = bbox.origin
+
+        return Image(data, yx0=(y0 + self.y0, x0 + self.x0))
+
+    def at(self, y: int, x: int) -> ScalarLike | np.ndarray:
+        """The value of the image at a given location.
+
+        Image does not implment single index access because the
+        result is a scalar, while indexing an image returns another image.
+
+        Parameters
+        ----------
+        y:
+            The y-coordinate of the location.
+        x:
+            The x-coordinate of the location.
+
+        Returns
+        -------
+        value:
+            The value of the image at the given location.
+        """
+        _y = y - self.y0
+        _x = x - self.x0
+        if len(self.shape) == 2:
+            return self.data[_y, _x]
+        return self.data[:, _y, _x]
+
     def _i_update(self, op: Callable, other: Image | ScalarLike) -> Image:
         """Update the data array in place.
 

--- a/python/lsst/scarlet/lite/image.py
+++ b/python/lsst/scarlet/lite/image.py
@@ -364,10 +364,10 @@ class Image:
         if bands is None or len(bands) == 0:
             # Using an empty tuple for the bands will result in a 2D image
             bands = ()
-            assert len(data.shape) == 2
+            assert data.ndim == 2
         else:
             bands = tuple(bands)
-            assert len(data.shape) == 3
+            assert data.ndim == 3
             if data.shape[0] != len(bands):
                 raise ValueError(f"Array has spectral size {data.shape[0]}, but {bands} bands")
         if yx0 is None:
@@ -468,6 +468,11 @@ class Image:
     def data(self) -> np.ndarray:
         """The image viewed as a numpy array."""
         return self._data
+
+    @property
+    def ndim(self) -> int:
+        """Number of dimensions in the image."""
+        return self._data.ndim
 
     def spectral_indices(self, bands: Sequence | slice) -> tuple[int, ...] | slice:
         """The indices to extract each band in `bands` in order from the image
@@ -737,6 +742,9 @@ class Image:
     def trimmed(self, threshold: float = 0) -> Image:
         """Return a copy of the image trimmed to a threshold.
 
+        This is essentially the smallest image that contains all of the
+        pixels above the threshold.
+
         Parameters
         ----------
         threshold:
@@ -774,7 +782,7 @@ class Image:
         """
         _y = y - self.y0
         _x = x - self.x0
-        if len(self.shape) == 2:
+        if self.ndim == 2:
             return self.data[_y, _x]
         return self.data[:, _y, _x]
 
@@ -1211,7 +1219,7 @@ class Image:
 
             data = self.data[full_index]
 
-            if len(data.shape) == 2:
+            if data.ndim == 2:
                 # Only a single band was selected, so return that band
                 return Image(data, yx0=yx0)
             return Image(data, bands=bands, yx0=yx0)

--- a/python/lsst/scarlet/lite/initialization.py
+++ b/python/lsst/scarlet/lite/initialization.py
@@ -293,6 +293,7 @@ class FactorizedInitialization:
         max_components: int = 2,
         convolved: Image | None = None,
         is_symmetric: bool = False,
+        is_connected: bool = False,
     ):
         if detect is None:
             # Build the morphology detection image
@@ -322,6 +323,7 @@ class FactorizedInitialization:
         self.monotonicity = monotonicity
         self.use_sparse_init = use_sparse_init
         self.is_symmetric = is_symmetric
+        self.is_connected = is_connected
 
         # Get the model PSF
         # Convolve the PSF in order to set the spectrum
@@ -422,6 +424,7 @@ class FactorizedInitialization:
             self.observation.noise_rms,
             monotonicity=self.monotonicity,
             is_symmetric=self.is_symmetric,
+            is_connected=self.is_connected,
         )
         return component
 
@@ -496,6 +499,7 @@ class FactorizedInitialization:
             bg_thresh=self.bg_thresh,
             monotonicity=self.monotonicity,
             is_symmetric=self.is_symmetric,
+            is_connected=self.is_connected,
         )
 
     def init_source(self, center: tuple[int, int]) -> Source:
@@ -578,6 +582,7 @@ class FactorizedInitialization:
                         bg_thresh=self.bg_thresh,
                         monotonicity=self.monotonicity,
                         is_symmetric=self.is_symmetric,
+                        is_connected=self.is_connected,
                     ),
                     FactorizedComponent(
                         bands=self.observation.bands,
@@ -589,6 +594,7 @@ class FactorizedInitialization:
                         bg_thresh=self.bg_thresh,
                         monotonicity=self.monotonicity,
                         is_symmetric=self.is_symmetric,
+                        is_connected=self.is_connected,
                     ),
                 ]
             except np.linalg.LinAlgError:
@@ -801,6 +807,7 @@ class FactorizedWaveletInitialization(FactorizedInitialization):
                             center,
                             monotonicity=self.monotonicity,
                             is_symmetric=self.is_symmetric,
+                            is_connected=self.is_connected,
                         )
                     )
                 else:
@@ -815,6 +822,7 @@ class FactorizedWaveletInitialization(FactorizedInitialization):
                             center,
                             monotonicity=self.monotonicity,
                             is_symmetric=self.is_symmetric,
+                            is_connected=self.is_connected,
                         )
                     )
                 else:

--- a/python/lsst/scarlet/lite/initialization.py
+++ b/python/lsst/scarlet/lite/initialization.py
@@ -357,10 +357,7 @@ class FactorizedInitialization:
 
     @property
     def thresh(self):
-        logger.warning(
-            "thresh is deprecated and will be removed after v29.0. "
-            "Use initial_bg_thresh instead."
-        )
+        logger.warning("thresh is deprecated and will be removed after v29.0. Use initial_bg_thresh instead.")
         return self.initial_bg_thresh
 
     def get_snr(self, center: tuple[int, int]) -> float:

--- a/python/lsst/scarlet/lite/initialization.py
+++ b/python/lsst/scarlet/lite/initialization.py
@@ -351,7 +351,7 @@ class FactorizedInitialization:
             if max_components == 0:
                 source = Source([self.get_psf_component(center)])
             else:
-                source = self.init_source((int(center[0]), int(center[1])))
+                source = self.init_source((int(round(center[0])), int(round(center[1]))))
             sources.append(source)
         self.sources = sources
 

--- a/python/lsst/scarlet/lite/initialization.py
+++ b/python/lsst/scarlet/lite/initialization.py
@@ -577,6 +577,7 @@ class FactorizedInitialization:
                         bg_rms=self.observation.noise_rms,
                         bg_thresh=self.bg_thresh,
                         monotonicity=self.monotonicity,
+                        is_symmetric=self.is_symmetric,
                     ),
                     FactorizedComponent(
                         bands=self.observation.bands,
@@ -587,6 +588,7 @@ class FactorizedInitialization:
                         bg_rms=self.observation.noise_rms,
                         bg_thresh=self.bg_thresh,
                         monotonicity=self.monotonicity,
+                        is_symmetric=self.is_symmetric,
                     ),
                 ]
             except np.linalg.LinAlgError:
@@ -798,6 +800,7 @@ class FactorizedWaveletInitialization(FactorizedInitialization):
                             bulge_box,
                             center,
                             monotonicity=self.monotonicity,
+                            is_symmetric=self.is_symmetric,
                         )
                     )
                 else:
@@ -811,6 +814,7 @@ class FactorizedWaveletInitialization(FactorizedInitialization):
                             disk_box,
                             center,
                             monotonicity=self.monotonicity,
+                            is_symmetric=self.is_symmetric,
                         )
                     )
                 else:

--- a/python/lsst/scarlet/lite/initialization.py
+++ b/python/lsst/scarlet/lite/initialization.py
@@ -349,7 +349,10 @@ class FactorizedInitialization:
 
     @property
     def thresh(self):
-        logger.warning("thresh is deprecated and will be removed after v29.0. " "Use initial_bg_thresh instead.")
+        logger.warning(
+            "thresh is deprecated and will be removed after v29.0. "
+            "Use initial_bg_thresh instead."
+        )
         return self.initial_bg_thresh
 
     def get_snr(self, center: tuple[int, int]) -> float:
@@ -757,7 +760,7 @@ class FactorizedWaveletInitialization(FactorizedInitialization):
             if bulge_morph is None or disk_morph is None:
                 if bulge_morph is None:
                     if disk_morph is None:
-                        return None
+                        raise RuntimeError("Both components are None")
                 # One of the components was null,
                 # so initialize as a single component
                 component = self.get_single_component(center, self.detectlets, 0, self.disk_grow)

--- a/python/lsst/scarlet/lite/initialization.py
+++ b/python/lsst/scarlet/lite/initialization.py
@@ -271,6 +271,10 @@ class FactorizedInitialization:
     convolved:
         Deprecated. This is now calculated in __init__, but the
         old API is supported until v29.0.
+    is_symmetric:
+        Whether or not the source is symmetric.
+        This is used to determine if the morphology should be
+        forced to be symmetric.
     """
 
     def __init__(
@@ -288,6 +292,7 @@ class FactorizedInitialization:
         use_sparse_init: bool = True,
         max_components: int = 2,
         convolved: Image | None = None,
+        is_symmetric: bool = False,
     ):
         if detect is None:
             # Build the morphology detection image
@@ -316,6 +321,7 @@ class FactorizedInitialization:
         self.min_snr = min_snr
         self.monotonicity = monotonicity
         self.use_sparse_init = use_sparse_init
+        self.is_symmetric = is_symmetric
 
         # Get the model PSF
         # Convolve the PSF in order to set the spectrum
@@ -415,6 +421,7 @@ class FactorizedInitialization:
             center,
             self.observation.noise_rms,
             monotonicity=self.monotonicity,
+            is_symmetric=self.is_symmetric,
         )
         return component
 
@@ -488,6 +495,7 @@ class FactorizedInitialization:
             bg_rms=self.observation.noise_rms,
             bg_thresh=self.bg_thresh,
             monotonicity=self.monotonicity,
+            is_symmetric=self.is_symmetric,
         )
 
     def init_source(self, center: tuple[int, int]) -> Source:

--- a/python/lsst/scarlet/lite/initialization.py
+++ b/python/lsst/scarlet/lite/initialization.py
@@ -20,10 +20,10 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import logging
-from abc import ABC, abstractmethod
 from typing import Sequence, cast
 
 import numpy as np
+from deprecated.sphinx import deprecated  # type: ignore
 
 from .bbox import Box
 from .component import FactorizedComponent
@@ -39,8 +39,9 @@ logger = logging.getLogger("scarlet.lite.initialization")
 
 def trim_morphology(
     morph: np.ndarray,
-    bg_thresh: float = 0,
+    thresh: float = 0,
     padding: int = 5,
+    bg_thresh: float | None = None,
 ) -> tuple[np.ndarray, Box]:
     """Trim the morphology up to pixels above a threshold
 
@@ -48,8 +49,10 @@ def trim_morphology(
     ----------
     morph:
         The morphology to be trimmed.
-    bg_thresh:
+    thresh:
         The morphology is trimmed to pixels above the threshold.
+    bg_thresh:
+        Deprecated in favor of `thresh`.
     padding:
         The amount to pad each side to allow the source to grow.
 
@@ -60,8 +63,13 @@ def trim_morphology(
     box:
         The box that contains the morphology.
     """
+    # Temporarily support bg_thresh
+    if bg_thresh is not None:
+        logger.warning("bg_thresh is deprecated and will be removed in v28.0. " "Use thresh instead.")
+        thresh = bg_thresh
+
     # trim morph to pixels above threshold
-    mask = morph > bg_thresh
+    mask = morph > thresh
     morph[~mask] = 0
     bbox = Box.from_data(morph, threshold=0).grow(padding)
     return morph, bbox
@@ -75,6 +83,9 @@ def init_monotonic_morph(
     normalize: bool = True,
     monotonicity: Monotonicity | None = None,
     thresh: float = 0,
+    max_iter: int = 0,
+    center_radius: int = 1,
+    variance_factor: float = 0,
 ) -> tuple[Box, np.ndarray | None]:
     """Initialize a morphology for a monotonic source
 
@@ -98,8 +109,20 @@ def init_monotonic_morph(
         monotonic pixels, otherwise the monotonicity operator is used to
         project the morphology to a monotonic solution.
     thresh:
-        The threshold (fraction above the background) to use for trimming the
+        The threshold to use for trimming the
         morphology.
+    max_iter:
+        The maximum number of iterations to use in the monotonicity operator.
+        Only used if `monotonicity` is `None`.
+    center_radius:
+        The amount that the center can be shifted to a local maximum.
+        Only used if `monotonicity` is `None`.
+    variance_factor:
+        The average variance in the image.
+        This is used to allow pixels to be non-monotonic up to
+        `variance` * `noise_rms`, so setting `variance = 0`
+        will force strict monotonicity in the mask.
+        Only used if `monotonicity` is `None`.
 
     Returns
     -------
@@ -111,24 +134,28 @@ def init_monotonic_morph(
     center: tuple[int, int] = tuple(center[i] - full_box.origin[i] for i in range(2))  # type: ignore
 
     if monotonicity is None:
-        _, morph, bounds = prox_monotonic_mask(detect, center, max_iter=0)
+        _, morph, bounds = prox_monotonic_mask(
+            x=detect,
+            center=center,
+            center_radius=center_radius,
+            variance=variance_factor,
+            max_iter=max_iter,
+        )
         bbox = bounds_to_bbox(bounds)
         if bbox.shape == (1, 1) and morph[bbox.slices][0, 0] == 0:
             return Box((0, 0)), None
 
         if thresh > 0:
-            morph, bbox = trim_morphology(morph, bg_thresh=thresh, padding=padding)
-
-        # Shift the bounding box to account for the non-zero origin
-        bbox += full_box.origin
+            morph, bbox = trim_morphology(morph, thresh=thresh, padding=padding)
 
     else:
         morph = monotonicity(detect, center)
 
         # truncate morph at thresh * bg_rms
-        morph, bbox = trim_morphology(morph, bg_thresh=thresh, padding=padding)
-        # Shift the bounding box to account for the non-zero origin
-        bbox += full_box.origin
+        morph, bbox = trim_morphology(morph, thresh=thresh, padding=padding)
+
+    # Shift the bounding box to account for the non-zero origin
+    bbox += full_box.origin
 
     if np.max(morph) == 0:
         return Box((0, 0), origin=full_box.origin), None
@@ -194,8 +221,15 @@ def multifit_spectra(
     return spectra
 
 
-class FactorizedInitialization(ABC):
+class FactorizedInitialization:
     """Common variables and methods for both Factorized Component schemes
+
+    There are a large number of parameters that are universal for all of the
+    sources being initialized from the same set of observed images.
+    To simplify the API those parameters are all initialized by this class
+    and passed to `init_source` for each source.
+    It also creates temporary objects that only need to be created once for
+    all of the sources in a blend.
 
     Parameters
     ----------
@@ -203,6 +237,8 @@ class FactorizedInitialization(ABC):
         The observation containing the blend
     centers:
         The center of each source to initialize.
+    detect:
+        The array that contains a 2D image used for detection.
     min_snr:
         The minimum SNR required per component.
         So a 2-component source requires at least `2*min_snr` while sources
@@ -212,20 +248,68 @@ class FactorizedInitialization(ABC):
         the component is initialized with only the
         monotonic pixels, otherwise the monotonicity operator is used to
         project the morphology to a monotonic solution.
+    disk_percentile:
+        The percentage of the overall flux to attribute to the disk.
+    bg_thresh:
+        The fraction of the background RMS to use as a threshold for the
+        morphology (in other words the threshold is set at
+        `bg_thresh * noise_rms`).
+    initital_bg_thresh:
+        The same as bg_thresh, but this allows a different background
+        threshold to be used for initialization.
+    thresh:
+        Deprecated. Use `initial_bg_thresh` instead.
+    padding:
+        The amount to pad the morphology to allow for extra flux
+        in the first few iterations before resizing.
     use_sparse_init:
         Use a monotonic mask to prevent initial source models from growing
         too large.
+    max_components:
+        The maximum number of components in the source.
+        This should be one or two.
+    convolved:
+        Deprecated. This is now calculated in __init__, but the
+        old API is supported until v28.0.
     """
 
     def __init__(
         self,
         observation: Observation,
-        convolved: Image,
         centers: Sequence[tuple[int, int]],
+        detect: np.ndarray | None = None,
         min_snr: float = 50,
         monotonicity: Monotonicity | None = None,
+        disk_percentile: float = 25,
+        initial_bg_thresh: float = 0.5,
+        bg_thresh: float = 0.25,
+        thresh: float | None = None,
+        padding: int = 2,
         use_sparse_init: bool = True,
+        max_components: int = 2,
+        convolved: Image | None = None,
     ):
+        if detect is None:
+            # Build the morphology detection image
+            detect = np.sum(
+                observation.images.data / (observation.noise_rms**2)[:, None, None],
+                axis=0,
+            )
+        self.detect = detect
+
+        if convolved is None:
+            _detect = Image(detect)
+            convolved = observation.convolve(_detect.repeat(observation.bands), mode="real")
+        else:
+            logger.warning(
+                "convolved is deprecated and will be removed in v28.0. "
+                "The convolved image is now calculated in __init__ and does "
+                "not need to be specified."
+            )
+
+        if thresh is not None:
+            initial_bg_thresh = thresh
+
         self.observation = observation
         self.convolved = convolved
         self.centers = centers
@@ -237,19 +321,38 @@ class FactorizedInitialization(ABC):
         # Convolve the PSF in order to set the spectrum
         # of a point source correctly.
         model_psf = Image(cast(np.ndarray, observation.model_psf)[0])
-        convolved = model_psf.repeat(observation.bands)
-        self.convolved_psf = observation.convolve(convolved, mode="real").data
+        convolved_psf = model_psf.repeat(observation.bands)
+        self.convolved_psf = observation.convolve(convolved_psf, mode="real").data
         # Get the "spectrum" of the PSF
         self.py = model_psf.shape[0] // 2
         self.px = model_psf.shape[1] // 2
         self.psf_spectrum = self.convolved_psf[:, self.py, self.px]
 
+        # Set the maximum number of components for any source in the blend
+        if max_components < 0 or max_components > 2:
+            raise ValueError(f"max_components must be 0, 1 or 2, got {max_components}")
+        self.max_components = max_components
+        self.initial_bg_thresh = initial_bg_thresh
+        self.bg_thresh = bg_thresh
+        self.padding = padding
+        self.disk_percentile = disk_percentile
+
         # Initalize all of the sources
         sources = []
         for center in centers:
-            source = self.init_source((int(center[0]), int(center[1])))
+            if max_components == 0:
+                source = Source([self.get_psf_component(center)])
+            else:
+                source = self.init_source((int(center[0]), int(center[1])))  # type: ignore
+                if source is None:
+                    raise ValueError(f"Source at {center} could not be initialized")
             sources.append(source)
         self.sources = sources
+
+    @property
+    def thresh(self):
+        logger.warning("thresh is deprecated and will be removed in v28.0. " "Use initial_bg_thresh instead.")
+        return self.initial_bg_thresh
 
     def get_snr(self, center: tuple[int, int]) -> float:
         """Get the SNR at the center of a component
@@ -376,98 +479,15 @@ class FactorizedInitialization(ABC):
         morph /= morph_max
 
         return FactorizedComponent(
-            self.observation.bands,
-            spectrum,
-            morph,
-            bbox,
-            center,
-            self.observation.noise_rms,
+            bands=self.observation.bands,
+            spectrum=spectrum,
+            morph=morph,
+            bbox=bbox,
+            peak=center,
+            bg_rms=self.observation.noise_rms,
+            bg_thresh=self.bg_thresh,
             monotonicity=self.monotonicity,
         )
-
-    @abstractmethod
-    def init_source(self, center: tuple[int, int]) -> Source | None:
-        """Initialize a source
-
-        Parameters
-        ----------
-        center:
-            The center of the source.
-        """
-
-
-class FactorizedChi2Initialization(FactorizedInitialization):
-    """Initialize all sources with chi^2 detections
-
-    There are a large number of parameters that are universal for all of the
-    sources being initialized from the same set of observed images.
-    To simplify the API those parameters are all initialized by this class
-    and passed to `init_main_source` for each source.
-    It also creates temporary objects that only need to be created once for
-    all of the sources in a blend.
-
-    Parameters
-    ----------
-    observation:
-        The observation containing the blend
-    centers:
-        The center of each source to initialize.
-    detect:
-        The array that contains a 2D image used for detection.
-    min_snr:
-        The minimum SNR required per component.
-        So a 2-component source requires at least `2*min_snr` while sources
-        with SNR < `min_snr` will be initialized with the PSF.
-    monotonicity:
-        When `monotonicity` is `None`,
-        the component is initialized with only the
-        monotonic pixels, otherwise the monotonicity operator is used to
-        project the morphology to a monotonic solution.
-    disk_percentile:
-        The percentage of the overall flux to attribute to the disk.
-    thresh:
-        The threshold used to trim the morphology,
-        so all pixels below `thresh * bg_rms` are set to zero.
-    padding:
-        The amount to pad the morphology to allow for extra flux
-        in the first few iterations before resizing.
-    """
-
-    def __init__(
-        self,
-        observation: Observation,
-        centers: Sequence[tuple[int, int]],
-        detect: np.ndarray | None = None,
-        min_snr: float = 50,
-        monotonicity: Monotonicity | None = None,
-        disk_percentile: float = 25,
-        thresh: float = 0.5,
-        padding: int = 2,
-    ):
-        if detect is None:
-            # Build the morphology detection image
-            detect = np.sum(
-                observation.images.data / (observation.noise_rms**2)[:, None, None],
-                axis=0,
-            )
-        self.detect = detect
-        _detect = Image(detect)
-        # Convolve the detection image.
-        # This may seem counter-intuitive,
-        # since this is effectively growing the model,
-        # but this is exactly what convolution will do to the model
-        # in each iteration.
-        # So we create the convolved model in order
-        # to correctly set the spectrum.
-        convolved = observation.convolve(_detect.repeat(observation.bands), mode="real")
-
-        # Set the input parameters
-        self.disk_percentile = disk_percentile
-        self.thresh = thresh
-        self.padding = padding
-
-        # Initialize the sources
-        super().__init__(observation, convolved, centers, min_snr, monotonicity)
 
     def init_source(self, center: tuple[int, int]) -> Source | None:
         """Initialize a source from a chi^2 detection.
@@ -493,12 +513,12 @@ class FactorizedChi2Initialization(FactorizedInitialization):
         # Initialize the bbox, morph, and spectrum
         # for a single component source
         detect = prox_uncentered_symmetry(self.detect.copy(), local_center, fill=0)
-        thresh = np.mean(self.observation.noise_rms) * self.thresh
+        thresh = np.mean(self.observation.noise_rms) * self.initial_bg_thresh
         component = self.get_single_component(center, detect, thresh, self.padding)
 
         if component is None:
             components = [self.get_psf_component(center)]
-        elif component_snr < 2:
+        elif component_snr < 2 or self.max_components < 2:
             components = [component]
         else:
             # There was enough flux for a 2-component source,
@@ -537,21 +557,23 @@ class FactorizedChi2Initialization(FactorizedInitialization):
 
                 components = [
                     FactorizedComponent(
-                        self.observation.bands,
-                        bulge_spectrum,
-                        bulge_morph,
-                        component.bbox.copy(),
-                        center,
-                        self.observation.noise_rms,
+                        bands=self.observation.bands,
+                        spectrum=bulge_spectrum,
+                        morph=bulge_morph,
+                        bbox=component.bbox.copy(),
+                        peak=center,
+                        bg_rms=self.observation.noise_rms,
+                        bg_thresh=self.bg_thresh,
                         monotonicity=self.monotonicity,
                     ),
                     FactorizedComponent(
-                        self.observation.bands,
-                        disk_spectrum,
-                        disk_morph,
-                        component.bbox.copy(),
-                        center,
-                        self.observation.noise_rms,
+                        bands=self.observation.bands,
+                        spectrum=disk_spectrum,
+                        morph=disk_morph,
+                        bbox=component.bbox.copy(),
+                        peak=center,
+                        bg_rms=self.observation.noise_rms,
+                        bg_thresh=self.bg_thresh,
                         monotonicity=self.monotonicity,
                     ),
                 ]
@@ -561,6 +583,59 @@ class FactorizedChi2Initialization(FactorizedInitialization):
         return Source(components)  # type: ignore
 
 
+@deprecated(
+    reason="This class is replaced by FactorizedInitialization and will be removed in v28.0",
+    version="v28.0",
+    category=FutureWarning,
+)
+class FactorizedChi2Initialization(FactorizedInitialization):
+    """Initialize all sources with chi^2 detections
+
+    There are a large number of parameters that are universal for all of the
+    sources being initialized from the same set of observed images.
+    To simplify the API those parameters are all initialized by this class
+    and passed to `init_main_source` for each source.
+    It also creates temporary objects that only need to be created once for
+    all of the sources in a blend.
+
+    Parameters
+    ----------
+    observation:
+        The observation containing the blend
+    centers:
+        The center of each source to initialize.
+    detect:
+        The array that contains a 2D image used for detection.
+    min_snr:
+        The minimum SNR required per component.
+        So a 2-component source requires at least `2*min_snr` while sources
+        with SNR < `min_snr` will be initialized with the PSF.
+    monotonicity:
+        When `monotonicity` is `None`,
+        the component is initialized with only the
+        monotonic pixels, otherwise the monotonicity operator is used to
+        project the morphology to a monotonic solution.
+    disk_percentile:
+        The percentage of the overall flux to attribute to the disk.
+    thresh:
+        The threshold used to trim the morphology,
+        so all pixels below `thresh * bg_rms` are set to zero.
+    padding:
+        The amount to pad the morphology to allow for extra flux
+        in the first few iterations before resizing.
+    """
+
+    pass
+
+
+@deprecated(
+    reason="FactorizedWaveletInitialization will be removed in v28.0 "
+    "since it does not appear to offer any advantages over "
+    "FactorizedChi2Initialization. Consider switching to "
+    "FactorizedInitialization now.",
+    version="v28.0",
+    category=FutureWarning,
+)
 class FactorizedWaveletInitialization(FactorizedInitialization):
     """Parameters used to initialize all sources with wavelet detections
 
@@ -614,6 +689,7 @@ class FactorizedWaveletInitialization(FactorizedInitialization):
         wavelets: np.ndarray | None = None,
         monotonicity: Monotonicity | None = None,
         min_snr: float = 50,
+        use_sparse_init: bool = True,
     ):
         if wavelets is None:
             wavelets = get_detect_wavelets(
@@ -629,10 +705,6 @@ class FactorizedWaveletInitialization(FactorizedInitialization):
         # The detection coadd for the disk
         disklets = np.sum(wavelets[disk_slice], axis=0)
 
-        # The convolved image, used to initialize the spectrum
-        detect = Image(detectlets)
-        convolved = observation.convolve(detect.repeat(observation.bands), mode="real")
-
         self.detectlets = detectlets
         self.bulgelets = bulgelets
         self.disklets = disklets
@@ -641,7 +713,14 @@ class FactorizedWaveletInitialization(FactorizedInitialization):
         self.use_psf = use_psf
 
         # Initialize the sources
-        super().__init__(observation, convolved, centers, min_snr, monotonicity)
+        super().__init__(
+            observation=observation,
+            centers=centers,
+            detect=detectlets,
+            min_snr=min_snr,
+            monotonicity=monotonicity,
+            use_sparse_init=use_sparse_init,
+        )
 
     def init_source(self, center: tuple[int, int]) -> Source | None:
         """Initialize a source from a chi^2 detection.

--- a/python/lsst/scarlet/lite/observation.py
+++ b/python/lsst/scarlet/lite/observation.py
@@ -349,7 +349,7 @@ class Observation:
         return result
 
     def __getitem__(self, indices: Any) -> Observation:
-        """Get the subset of an image
+        """Get a view for the subset of an image
 
         Parameters
         ----------

--- a/python/lsst/scarlet/lite/operators.py
+++ b/python/lsst/scarlet/lite/operators.py
@@ -275,7 +275,7 @@ def get_peak(image: np.ndarray, center: tuple[int, int], radius: int = 1) -> tup
     new_center:
         The true center of the source.
     """
-    cy, cx = int(center[0]), int(center[1])
+    cy, cx = int(round(center[0])), int(round(center[1]))
     y0 = np.max([cy - radius, 0])
     x0 = np.max([cx - radius, 0])
     y_slice = slice(y0, cy + radius + 1)
@@ -395,8 +395,8 @@ def uncentered_operator(
     if py == cy and px == cx:
         return func(x, **kwargs)
 
-    dy = int(2 * (py - cy))
-    dx = int(2 * (px - cx))
+    dy = int(round(2 * (py - cy)))
+    dx = int(round(2 * (px - cx)))
     if not x.shape[0] % 2:
         dy += 1
     if not x.shape[1] % 2:

--- a/python/lsst/scarlet/lite/operators.py
+++ b/python/lsst/scarlet/lite/operators.py
@@ -132,9 +132,9 @@ class Monotonicity:
         # and calculate the distance to each pixel from the center
         cx = (shape[1] - 1) // 2
         cy = (shape[0] - 1) // 2
-        x = np.arange(shape[1], dtype=self.dtype) - cx
-        y = np.arange(shape[0], dtype=self.dtype) - cy
-        x, y = np.meshgrid(x, y)
+        _x = np.arange(shape[1], dtype=self.dtype) - cx
+        _y = np.arange(shape[0], dtype=self.dtype) - cy
+        x, y = np.meshgrid(_x, _y)
         distance = np.sqrt(x**2 + y**2)
 
         # Calculate the distance from each pixel to its 8 nearest neighbors

--- a/python/lsst/scarlet/lite/utils.py
+++ b/python/lsst/scarlet/lite/utils.py
@@ -120,8 +120,8 @@ def get_circle_mask(diameter: int, dtype: npt.DTypeLike = np.float64):
         radius = diameter / 2
     else:
         radius = c
-    x = np.arange(diameter)
-    x, y = np.meshgrid(x, x)
+    _x = np.arange(diameter)
+    x, y = np.meshgrid(_x, _x)
     r = np.sqrt((x - c) ** 2 + (y - c) ** 2)
 
     circle = np.ones((diameter, diameter), dtype=dtype)

--- a/python/lsst/scarlet/lite/wavelet.py
+++ b/python/lsst/scarlet/lite/wavelet.py
@@ -243,7 +243,7 @@ class MultiResolutionSupport:
 def get_multiresolution_support(
     image: np.ndarray,
     starlets: np.ndarray,
-    sigma: float,
+    sigma: np.floating,
     sigma_scaling: float = 3,
     epsilon: float = 1e-1,
     max_iter: int = 20,
@@ -335,7 +335,7 @@ def get_multiresolution_support(
 
 def apply_wavelet_denoising(
     image: np.ndarray,
-    sigma: float | None = None,
+    sigma: np.floating | None = None,
     sigma_scaling: float = 3,
     epsilon: float = 1e-1,
     max_iter: int = 20,

--- a/tests/test_blend.py
+++ b/tests/test_blend.py
@@ -24,7 +24,7 @@ from typing import Callable, cast
 import numpy as np
 from lsst.scarlet.lite import Blend, Box, Image, Observation, Source
 from lsst.scarlet.lite.component import Component, FactorizedComponent, default_adaprox_parameterization
-from lsst.scarlet.lite.initialization import FactorizedChi2Initialization
+from lsst.scarlet.lite.initialization import FactorizedInitialization
 from lsst.scarlet.lite.operators import Monotonicity
 from lsst.scarlet.lite.parameters import Parameter
 from lsst.scarlet.lite.utils import integrated_circular_gaussian
@@ -196,7 +196,7 @@ class TestBlend(ScarletTestCase):
         observation.images._data += noise
 
         monotonicity = Monotonicity((101, 101))
-        init = FactorizedChi2Initialization(observation, self.centers, monotonicity=monotonicity)
+        init = FactorizedInitialization(observation, self.centers, monotonicity=monotonicity)
 
         blend = Blend(init.sources, self.observation).fit_spectra()
         blend.parameterize(default_adaprox_parameterization)

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -24,6 +24,7 @@ import os
 import numpy as np
 from lsst.scarlet.lite import Box, Image
 from lsst.scarlet.lite.detect import (
+    bbox_to_bounds,
     bounds_to_bbox,
     detect_footprints,
     footprints_to_image,
@@ -215,6 +216,10 @@ class TestDetect(ScarletTestCase):
         truth = Box((25, 42), (3, 11))
         bbox = bounds_to_bbox(bounds)
         self.assertBoxEqual(bbox, truth)
+
+        # Check that the reverse operation also works
+        new_bounds = bbox_to_bounds(bbox)
+        self.assertTupleEqual(new_bounds, bounds)
 
     def test_footprint(self):
         footprint = self.sources[0].data

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -22,9 +22,10 @@
 import os
 
 import numpy as np
+from deprecated.sphinx import deprecated
 from lsst.scarlet.lite import Box, Image, Observation
 from lsst.scarlet.lite.initialization import (
-    FactorizedChi2Initialization,
+    FactorizedInitialization,
     FactorizedWaveletInitialization,
     init_monotonic_morph,
     multifit_spectra,
@@ -203,7 +204,7 @@ class TestInitialization(ScarletTestCase):
 
     def test_factorized_chi2_init(self):
         # Test default parameters
-        init = FactorizedChi2Initialization(self.observation, self.centers)
+        init = FactorizedInitialization(self.observation, self.centers)
         self.assertEqual(init.observation, self.observation)
         self.assertEqual(init.min_snr, 50)
         self.assertIsNone(init.monotonicity)
@@ -215,11 +216,15 @@ class TestInitialization(ScarletTestCase):
             self.assertEqual(src.get_model().dtype, np.float32)
 
         centers = tuple(tuple(center.astype(int)) for center in self.centers) + ((1000, 2004),)
-        init = FactorizedChi2Initialization(self.observation, centers)
+        init = FactorizedInitialization(self.observation, centers)
         self.assertEqual(len(init.sources), 8)
         for src in init.sources:
             self.assertEqual(src.get_model().dtype, np.float32)
 
+    @deprecated(
+        version="v28.0",
+        reason="FactorizedWaveletInitialization is deprecated and will be removed in v28.0",
+    )
     def test_factorized_wavelet_init(self):
         # Test default parameters
         init = FactorizedWaveletInitialization(self.observation, self.centers)

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -222,8 +222,8 @@ class TestInitialization(ScarletTestCase):
             self.assertEqual(src.get_model().dtype, np.float32)
 
     @deprecated(
-        version="v28.0",
-        reason="FactorizedWaveletInitialization is deprecated and will be removed in v28.0",
+        version="v29.0",
+        reason="FactorizedWaveletInitialization is deprecated and will be removed after v29.0",
     )
     def test_factorized_wavelet_init(self):
         # Test default parameters

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -24,7 +24,7 @@ import os
 
 import numpy as np
 from lsst.scarlet.lite import Blend, Image, Observation, io
-from lsst.scarlet.lite.initialization import FactorizedChi2Initialization
+from lsst.scarlet.lite.initialization import FactorizedInitialization
 from lsst.scarlet.lite.models.free_form import FactorizedFreeFormComponent
 from lsst.scarlet.lite.operators import Monotonicity
 from lsst.scarlet.lite.utils import integrated_circular_gaussian
@@ -50,7 +50,7 @@ class TestIo(ScarletTestCase):
             bands=bands,
         )
         monotonicity = Monotonicity((101, 101))
-        init = FactorizedChi2Initialization(self.observation, self.centers, monotonicity=monotonicity)
+        init = FactorizedInitialization(self.observation, self.centers, monotonicity=monotonicity)
         self.blend = Blend(init.sources, self.observation)
 
     def test_json(self):

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -24,7 +24,7 @@ import os
 import numpy as np
 from lsst.scarlet.lite import Blend, Image, Observation, Source, io
 from lsst.scarlet.lite.component import default_adaprox_parameterization
-from lsst.scarlet.lite.initialization import FactorizedChi2Initialization
+from lsst.scarlet.lite.initialization import FactorizedInitialization
 from lsst.scarlet.lite.measure import calculate_snr
 from lsst.scarlet.lite.operators import Monotonicity
 from lsst.scarlet.lite.utils import integrated_circular_gaussian
@@ -73,7 +73,7 @@ class TestMeasurements(ScarletTestCase):
             bands=bands,
         )
         monotonicity = Monotonicity((101, 101))
-        init = FactorizedChi2Initialization(observation, centers, monotonicity=monotonicity)
+        init = FactorizedInitialization(observation, centers, monotonicity=monotonicity)
 
         blend = Blend(init.sources, observation).fit_spectra()
         blend.sources.append(Source([]))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -27,7 +27,7 @@ import lsst.scarlet.lite.models as models
 import numpy as np
 from lsst.scarlet.lite import Blend, Box, FistaParameter, Image, Observation, Source
 from lsst.scarlet.lite.component import Component, FactorizedComponent, default_adaprox_parameterization
-from lsst.scarlet.lite.initialization import FactorizedChi2Initialization
+from lsst.scarlet.lite.initialization import FactorizedInitialization
 from lsst.scarlet.lite.models import (
     CartesianFrame,
     EllipseFrame,
@@ -407,7 +407,7 @@ class TestParametric(ScarletTestCase):
                 if isinstance(component, FittedPsfObservation):
                     component._fitted_kernel = FistaParameter(component._fitted_kernel.x, step=1e-2)
 
-        init = FactorizedChi2Initialization(observation, self.centers, monotonicity=monotonicity)
+        init = FactorizedInitialization(observation, self.centers, monotonicity=monotonicity)
         blend = FittedPsfBlend(init.sources, observation).fit_spectra()
         blend.parameterize(fista_parameterization)
         assert isinstance(cast(FittedPsfObservation, blend.observation)._fitted_kernel, FistaParameter)

--- a/tests/test_observation.py
+++ b/tests/test_observation.py
@@ -234,3 +234,54 @@ class TestObservation(ScarletTestCase):
             observation.images[bands],
             Image(np.array([image_g, image_r, image_i]), bands=("g", "r", "i")),
         )
+
+    def test_slicing(self):
+        np.random.seed(25)
+        all_bands = tuple("grizy")
+        images = np.random.random((5, 11, 13))
+        variance = np.arange(5)[:, None, None] * np.ones((5, 11, 13)) + 1
+        weights = 1 / variance
+        psfs = np.arange(5)[:, None, None] * np.ones((5, 2, 2))
+        model_psf = np.zeros(9).reshape(3, 3)
+        model_psf[1] = 1
+        model_psf[:, 1] = 1
+        model_psf[1, 1] = 2
+        bbox = Box((11, 13), origin=(12, 10))
+        observation = Observation(
+            images,
+            variance,
+            weights,
+            psfs,
+            model_psf[None],
+            bands=all_bands,
+            bbox=bbox,
+        )
+
+        new_box = Box((3, 4), origin=(15, 13))
+        sliced_bands = tuple("riz")
+        sliced_observation = observation[sliced_bands, new_box]
+        self.assertImageEqual(
+            sliced_observation.images["r":"z"],
+            Image(images[1:4, 3:6, 3:7], bands=sliced_bands, yx0=new_box.origin),
+        )
+        self.assertImageEqual(
+            sliced_observation.variance["r":"z"],
+            Image(variance[1:4, 3:6, 3:7], bands=sliced_bands, yx0=new_box.origin),
+        )
+        self.assertImageEqual(
+            sliced_observation.weights["r":"z"],
+            Image(weights[1:4, 3:6, 3:7], bands=sliced_bands, yx0=new_box.origin),
+        )
+        np.testing.assert_array_almost_equal(
+            sliced_observation.psfs,
+            psfs[1:4],
+        )
+        np.testing.assert_array_almost_equal(
+            sliced_observation.model_psf,
+            model_psf[None, :, :],
+        )
+        np.testing.assert_array_almost_equal(
+            sliced_observation.noise_rms,
+            observation.noise_rms[1:4],
+        )
+        self.assertBoxEqual(sliced_observation.bbox, new_box)


### PR DESCRIPTION
Truncating peak positions without rounding was leading to an additive bias in shear measurements. This PR fixes that issue while also adding a few additional constraints (symmetry and connectedness) as optional (but turned off by default) constraints for non-LSST users.