### PR TITLE
DM-55568: Automatically propagate the source ID if it is missing

### DIFF
--- a/python/lsst/scarlet/lite/io/blend.py
+++ b/python/lsst/scarlet/lite/io/blend.py
@@ -164,8 +164,13 @@ class ScarletBlendData(ScarletBlendBaseData):
             A scarlet blend model extracted from persisted data.
         """
         sources = []
-        for source_data in self.sources.values():
+        for sid, source_data in self.sources.items():
             source = source_data.to_source(observation)
+            # Ensure that the source id is persisted to its metadata
+            if source.metadata is None:
+                source.metadata = {}
+            if "id" not in source.metadata:
+                source.metadata["id"] = sid
             sources.append(source)
 
         return Blend(sources=sources, observation=observation, metadata=self.metadata)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -217,3 +217,10 @@ class TestIo(ScarletTestCase):
         self.assertEqual(len(blend.sources), len(loaded_blend.sources))
         self.assertEqual(len(blend.components), len(loaded_blend.components))
         self.assertImageAlmostEqual(blend.get_model(), loaded_blend.get_model())
+
+        # Legacy models (e.g. DP1) predate the source metadata field, so the
+        # source id is not stored in the source itself. Ensure that the id
+        # is propagated into ``source.metadata["id"]`` on load.
+        for sid, source in zip(model_data.blends[1].sources, loaded_blend.sources):
+            self.assertIsNotNone(source.metadata)
+            self.assertEqual(source.metadata["id"], sid)


### PR DESCRIPTION
In LSST DP1 there was no sense of metadata, so the ScarletBlendData class had no concept of storing the source ID as metadata. This fix ensures that DP1 models persist the source ID so that users can look up the object record associated with a given scarlet lite Source.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
