### PR TITLE
Persist DP1 source IDs to metadata

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ jobs:
         run: uv pip install --system -v -e .[plotting]
 
       - name: Install documenteer for doctest
-        run: uv pip install --system 'documenteer[pipelines]<0.8.2' 'sphinx-automodapi<0.20' 'sphinx-prompt<1.10' 'setuptools'
+        run: uv pip install --system 'documenteer[pipelines]<0.8.2' 'sphinx-automodapi<0.20' 'sphinx-prompt<1.10' 'setuptools<81'
 
       - name: Run tests
         run: >

--- a/python/lsst/scarlet/lite/io/blend.py
+++ b/python/lsst/scarlet/lite/io/blend.py
@@ -164,8 +164,13 @@ class ScarletBlendData(ScarletBlendBaseData):
             A scarlet blend model extracted from persisted data.
         """
         sources = []
-        for source_data in self.sources.values():
+        for sid, source_data in self.sources.items():
             source = source_data.to_source(observation)
+            # Ensure that the source id is persisted to its metadata
+            if source.metadata is None:
+                source.metadata = {}
+            if "id" not in source.metadata:
+                source.metadata["id"] = sid
             sources.append(source)
 
         return Blend(sources=sources, observation=observation, metadata=self.metadata)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -190,3 +190,10 @@ class TestIo(ScarletTestCase):
         self.assertEqual(len(blend.sources), len(loaded_blend.sources))
         self.assertEqual(len(blend.components), len(loaded_blend.components))
         self.assertImageAlmostEqual(blend.get_model(), loaded_blend.get_model())
+
+        # Legacy models (e.g. DP1) predate the source metadata field, so the
+        # source id is not stored in the source itself. Ensure that the id
+        # is propagated into ``source.metadata["id"]`` on load.
+        for sid, source in zip(model_data.blends[1].sources, loaded_blend.sources):
+            self.assertIsNotNone(source.metadata)
+            self.assertEqual(source.metadata["id"], sid)


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
